### PR TITLE
Patch taskruns on failed events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
-tw_version = $(shell git rev-parse HEAD)
+tag = 0.1.$(shell git rev-list --count master)
 image_name = alangh/tekton-watcher
-image = $(image_name):$(tw_version)
-latest_image = $(image_name):latest
-tag = 1.0.$(shellgit rev-list --count master)
+image = $(image_name):$(tag)
 
 .PHONY: build
 
@@ -10,7 +8,6 @@ build:
 	@docker build -t $(image) .
 
 release: build
-#	@git tag $(tag) && git push origin $(tag)
+	@git tag $(tag) && git push origin $(tag)
 	@docker push $(image)
-	@docker tag $(image) $(latest_image) && docker push $(latest_image)
 	@echo "Done"

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tekton-watcher-config
-data:
-  config.edn: |
-    {:tekton.dashboard/url "http://eb59abb6.ngrok.io"
-     :tekton/namespace "pipelines"}

--- a/app/tekton-watcher.yaml
+++ b/app/tekton-watcher.yaml
@@ -3,14 +3,18 @@ kind: Namespace
 metadata:
   name: tekton-watcher
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tekton-watcher-config
-  namespace: tekton-watcher
-data:
-  config.edn: |
-    {:tekton/namespace "pipelines"}
+###
+# The config map below can be used to customize tekton-watcher.
+# Remove the comments and apply it on the cluster.
+###
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: tekton-watcher-config
+#  namespace: tekton-watcher
+#data:
+#  config.edn: |
+#    {:tekton/namespace "my-namespace"}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/app/tekton-watcher.yaml
+++ b/app/tekton-watcher.yaml
@@ -73,7 +73,7 @@ spec:
       serviceAccountName: tekton-watcher
       containers:
         - name: tekton-watcher
-          image: alangh/tekton-watcher:0.1.6
+          image: alangh/tekton-watcher:0.1.9
           volumeMounts:
             - name: github-statuses-updater
               mountPath: "/etc/github-statuses-updater"

--- a/app/tekton-watcher.yaml
+++ b/app/tekton-watcher.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: tekton-watcher
       containers:
         - name: tekton-watcher
-          image: alangh/tekton-watcher:0.1.5
+          image: alangh/tekton-watcher:0.1.6
           volumeMounts:
             - name: github-statuses-updater
               mountPath: "/etc/github-statuses-updater"

--- a/app/tekton-watcher.yaml
+++ b/app/tekton-watcher.yaml
@@ -73,7 +73,7 @@ spec:
       serviceAccountName: tekton-watcher
       containers:
         - name: tekton-watcher
-          image: alangh/tekton-watcher:0.1.5
+          image: alangh/tekton-watcher:0.1.6
           volumeMounts:
             - name: github-statuses-updater
               mountPath: "/etc/github-statuses-updater"

--- a/app/tekton-watcher.yaml
+++ b/app/tekton-watcher.yaml
@@ -1,10 +1,25 @@
 apiVersion: v1
-kind: ServiceAccount
+kind: Namespace
 metadata:
   name: tekton-watcher
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-watcher-config
+  namespace: tekton-watcher
+data:
+  config.edn: |
+    {:tekton/namespace "pipelines"}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-watcher
+  namespace: tekton-watcher
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: tekton-watcher-role
 rules:
@@ -28,21 +43,23 @@ rules:
     - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: tekton-watcher-role-binding
 subjects:
   - kind: ServiceAccount
     name: tekton-watcher
+    namespace: tekton-watcher
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: tekton-watcher-role
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tekton-watcher
+  namespace: tekton-watcher
 spec:
   replicas: 1
   selector:
@@ -56,7 +73,7 @@ spec:
       serviceAccountName: tekton-watcher
       containers:
         - name: tekton-watcher
-          image: alangh/tekton-watcher
+          image: alangh/tekton-watcher:0.1.4
           volumeMounts:
             - name: github-statuses-updater
               mountPath: "/etc/github-statuses-updater"

--- a/app/tekton-watcher.yaml
+++ b/app/tekton-watcher.yaml
@@ -73,7 +73,7 @@ spec:
       serviceAccountName: tekton-watcher
       containers:
         - name: tekton-watcher
-          image: alangh/tekton-watcher:0.1.4
+          image: alangh/tekton-watcher:0.1.5
           volumeMounts:
             - name: github-statuses-updater
               mountPath: "/etc/github-statuses-updater"

--- a/app/tekton-watcher.yaml
+++ b/app/tekton-watcher.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: tekton-watcher
       containers:
         - name: tekton-watcher
-          image: alangh/tekton-watcher:0.1.6
+          image: alangh/tekton-watcher:0.1.9
           volumeMounts:
             - name: github-statuses-updater
               mountPath: "/etc/github-statuses-updater"

--- a/resources/tekton_watcher/config.edn
+++ b/resources/tekton_watcher/config.edn
@@ -4,6 +4,6 @@
  :tekton.api/url
  "{api.server/url}{tekton.api/path}/namespaces/{tekton/namespace}"
  :tekton/namespace "default"
- :tekton.dashboard/url "http://eb59abb6.ngrok.io"
+ :tekton.dashboard/url "http://localhost:8081"
  :tekton.dashboard/task-run
  "{tekton.dashboard/url}/#/namespaces/{tekton/namespace}/taskruns/{task-run}"}

--- a/src/tekton_watcher/runs.clj
+++ b/src/tekton_watcher/runs.clj
@@ -70,3 +70,7 @@
 (defsub run-succeeded :task-run/succeeded
   [task-run config]
   (add-label task-run config "completed-event-fired"))
+
+(defsub run-failed :task-run/failed
+  [task-run config]
+  (add-label task-run config "completed-event-fired"))

--- a/src/tekton_watcher/service.clj
+++ b/src/tekton_watcher/service.clj
@@ -12,6 +12,7 @@
 (def subscribers
   [runs/run-started
    runs/run-succeeded
+   runs/run-failed
    pulls/run-started
    pulls/run-succeeded
    pulls/run-failed])


### PR DESCRIPTION
Taskruns weren't being patched with the label that tekton-watcher uses to
identify runs that have already been observed. This was causing lots of repeated
calls to Github API.