### PR TITLE
Stop filtering pipelineruns and taskruns that fired running events

### DIFF
--- a/src/tekton_watcher/runs.clj
+++ b/src/tekton_watcher/runs.clj
@@ -49,7 +49,7 @@
   [config]
   (list-runs config
              "pipelineruns"
-             "tekton-watcher/running-event-fired,!tekton-watcher/completed-event-fired"
+             "!tekton-watcher/completed-event-fired"
              pipelinerun-completed?))
 
 (defn get-running-taskruns
@@ -66,7 +66,7 @@
   [config]
   (list-runs config
              "taskruns"
-             "tekton-watcher/running-event-fired,!tekton-watcher/completed-event-fired"
+             "!tekton-watcher/completed-event-fired"
              taskrun-completed?))
 
 (defn- add-label

--- a/test/tekton_watcher/runs_test.clj
+++ b/test/tekton_watcher/runs_test.clj
@@ -115,7 +115,7 @@
     (providing [(http-client/send-and-await #:http{:url          "{url}/{resource-kind}"
                                                    :path-params  {:url           "url"
                                                                   :resource-kind "pipelineruns"}
-                                                   :query-params {:labelSelector "tekton-watcher/running-event-fired,!tekton-watcher/completed-event-fired"}})
+                                                   :query-params {:labelSelector "!tekton-watcher/completed-event-fired"}})
                 {:items [in-progress-pipelinerun succeeded-pipelinerun failed-pipelinerun]}]
                (is (= [succeeded-pipelinerun failed-pipelinerun]
                       (runs/get-completed-pipelineruns {:tekton.api/url "url"}))))))
@@ -134,7 +134,7 @@
     (providing [(http-client/send-and-await #:http{:url          "{url}/{resource-kind}"
                                                    :path-params  {:url           "url"
                                                                   :resource-kind "taskruns"}
-                                                   :query-params {:labelSelector "tekton-watcher/running-event-fired,!tekton-watcher/completed-event-fired"}})
+                                                   :query-params {:labelSelector "!tekton-watcher/completed-event-fired"}})
                 {:items [in-progress-taskrun succeeded-taskrun failed-taskrun]}]
                (is (= [succeeded-taskrun failed-taskrun]
                       (runs/get-completed-taskruns {:tekton.api/url "url"}))))))


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] You have a descriptive commit message with a short title (first line).
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [ ] Docs have been added / updated (for bug fixes / features).


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** 
When a pipelinerun/taskrun goes directly to failed due to some miss configuration or if tekton-watcher isn't fast enough to detect that a pipelinerun or taskrun is running, the status checks get stuck in "expected" state. 
This happens because we only get completed pipelineruns/taskruns that has the label `tekton-watcher/running-event-fired`

* **What is the new behavior (if this is a feature change)?**
Every pipelinerun/taskrun completed triggers the code to update the status check (not only pipelineruns/taskruns that had `tekton-watcher/running-event-fired` label)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: